### PR TITLE
Fix CVE-2015-8851

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Password changing has been protected differently from editing a user profile.
 - Passwords are stored as credentials, instead of in the user object.
 - TOTP Two-Factor authentication.
+- CVE-2015-8851: node-uuid prior to 1.4.4 uses insecure random number generator.
 
 ### Changed
 - Gulpfile refactored into smaller chunks.

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lodash": "^3.10.1",
     "morgan": "~1.7",
     "multer": "^1.1.0",
-    "node-uuid": "^1.4.3",
+    "node-uuid": "^1.4.7",
     "notp": "^2.0.3",
     "passport": "~0.3.0",
     "passport-anonymous": "^1.0.1",


### PR DESCRIPTION
Not actually a real issue, but it's bad form to leave known insecure code around: 

[CVE-2015-8851 - node-uuid uses insecure random number generator](https://nodesecurity.io/advisories/uuid_insecure-entropy-source-mathrandom)

