### PR TITLE
Caching the SQL query generation to cache the slow squel part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This version is incompatible with 0.1.x and 0.2.x databases.  The upgrade path f
 - Can disable the search on the sidebar for child pages.
 - Caching SQL requests in redis:
   - fetchMostRecentChange
+- Caching the SQL query generation to cache the slow squel part (424 ops/s vs. 102 ops/s)
 
 ### Changed
 - Upgraded to textblocks-0.14, removed support for pragma blocks entirely.

--- a/lib/query.js
+++ b/lib/query.js
@@ -528,6 +528,8 @@ exports.fetchMostRecentChange = function(db, cache, ctx, next) {
   });
 };
 
+var cachedQueryFetchEffectivePermissionsNobody = undefined;
+
 /**
  * Fetch a node's effective permissions (this works even if a node doesn't exist)
  *
@@ -547,7 +549,7 @@ exports.fetchEffectivePermissions = function(db, ctx, user, path, next) {
   async.waterfall([
     db.connectWrap,
     function(client, done, callback) {
-      var s, qname;
+      var s;
       if (user) {
         s = squel.select()
             .field('permission')
@@ -557,18 +559,26 @@ exports.fetchEffectivePermissions = function(db, ctx, user, path, next) {
                   'wh_permission_to_role.role = wh_subject_to_roles.role')
             .where('subject = ?', user.toDottedPath())
             .where('ltree(text(?)) ~ wh_permission_to_role.query', path.toDottedPath());
-        qname = 'fetch_effective_permissions';
+        q = s.toParam();
+        q.name = 'fetch_effective_permissions';
       } else {
-        s = squel.select()
-            .field('permission')
-            .field('role')
-            .from('wh_permission_to_role')
-            .where('role = ?', 'nobody')
-            .where('ltree(text(?)) ~ wh_permission_to_role.query', path.toDottedPath());
-        qname = 'fetch_effective_permissions_noobdy';
+        if (cachedQueryFetchEffectivePermissionsNobody) {
+          q = {
+            text: cachedQueryFetchEffectivePermissionsNobody.text, 
+            name: cachedQueryFetchEffectivePermissionsNobody.name, 
+            values: [path.toDottedPath()]};
+        } else {
+          s = squel.select()
+              .field('permission')
+              .field('role')
+              .from('wh_permission_to_role')
+              .where('role = \'nobody\'')
+              .where('ltree(text(?)) ~ wh_permission_to_role.query', path.toDottedPath());
+          q = s.toParam();
+          q.name = 'fetch_effective_permissions_noobdy';
+          cachedQueryFetchEffectivePermissionsNobody = {text: q.text, name: 'fetch_effective_permissions_noobdy'};
+        }
       }
-      var q = s.toParam();
-      q.name = qname;
       client.query(q, function(err, result) {
         callback(err, done, result);
       });
@@ -599,6 +609,8 @@ exports.fetchEffectivePermissions = function(db, ctx, user, path, next) {
   });
 };
 
+var cachedQueryFetchViaEntityTable = undefined;
+
 function fetchViaEntityTable(db, Entity, ctx, access, path, permissions, next) {
   var q;
   boundLogger.info('fetchViaEntityTable', {
@@ -609,10 +621,19 @@ function fetchViaEntityTable(db, Entity, ctx, access, path, permissions, next) {
   async.waterfall([
     db.connectWrap,
     function(client, done, callback) {
-      var s = squel.select().from('wh_entity');
-      sql.searchFields(s, sql.entityFields()).where('path = ?', path.toDottedPath());
-      q = s.toParam();
-      q.name = 'select_entity_query';
+      if (cachedQueryFetchViaEntityTable) {
+        q = {
+          text: cachedQueryFetchViaEntityTable.text, 
+          name: cachedQueryFetchViaEntityTable.name, 
+          values: [path.toDottedPath()]};
+      } else {
+        var s = squel.select().from('wh_entity');
+        sql.searchFields(s, sql.entityFields()).where('path = ?', path.toDottedPath());
+        q = s.toParam();
+        cachedQueryFetchViaEntityTable = {text: q.text, name: 'select_entity_query'};
+        q.name = 'select_entity_query';
+      }
+      
       client.query(q, function(err, result) {
         callback(err, done, result);
       });

--- a/lib/query.js
+++ b/lib/query.js
@@ -528,7 +528,7 @@ exports.fetchMostRecentChange = function(db, cache, ctx, next) {
   });
 };
 
-var cachedQueryFetchEffectivePermissionsNobody = undefined;
+var cachedQueryFetchEffectivePermissionsNobody;
 
 /**
  * Fetch a node's effective permissions (this works even if a node doesn't exist)
@@ -564,8 +564,8 @@ exports.fetchEffectivePermissions = function(db, ctx, user, path, next) {
       } else {
         if (cachedQueryFetchEffectivePermissionsNobody) {
           q = {
-            text: cachedQueryFetchEffectivePermissionsNobody.text, 
-            name: cachedQueryFetchEffectivePermissionsNobody.name, 
+            text: cachedQueryFetchEffectivePermissionsNobody.text,
+            name: cachedQueryFetchEffectivePermissionsNobody.name,
             values: [path.toDottedPath()]};
         } else {
           s = squel.select()
@@ -609,7 +609,7 @@ exports.fetchEffectivePermissions = function(db, ctx, user, path, next) {
   });
 };
 
-var cachedQueryFetchViaEntityTable = undefined;
+var cachedQueryFetchViaEntityTable;
 
 function fetchViaEntityTable(db, Entity, ctx, access, path, permissions, next) {
   var q;
@@ -623,8 +623,8 @@ function fetchViaEntityTable(db, Entity, ctx, access, path, permissions, next) {
     function(client, done, callback) {
       if (cachedQueryFetchViaEntityTable) {
         q = {
-          text: cachedQueryFetchViaEntityTable.text, 
-          name: cachedQueryFetchViaEntityTable.name, 
+          text: cachedQueryFetchViaEntityTable.text,
+          name: cachedQueryFetchViaEntityTable.name,
           values: [path.toDottedPath()]};
       } else {
         var s = squel.select().from('wh_entity');
@@ -633,7 +633,7 @@ function fetchViaEntityTable(db, Entity, ctx, access, path, permissions, next) {
         cachedQueryFetchViaEntityTable = {text: q.text, name: 'select_entity_query'};
         q.name = 'select_entity_query';
       }
-      
+
       client.query(q, function(err, result) {
         callback(err, done, result);
       });


### PR DESCRIPTION
query#entityFromPath
Root access: 102 op/s -> 424 op/s
Root access minus DB: 151 op/s -> 2926 op/s
nobody access: 299 op/s -> 449 op/s
nobody access minus DB: 241 op/s -> 1844 op/s