### PR TITLE
Added the ability to load history with rm3load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ This version is incompatible with 0.1.x and 0.2.x databases.  The upgrade path f
 - Added `RM3_LISTEN_HOST` so you can only listen on the localhost.
 - Added OpenGraph and Twitter Cards support.
 - Added link proto
+- Added the ability to load history with rm3load
+  - added --nohistory flag to smash history
+  - breaks on 0.2.0 backups currently because it tries to assign a user to a permission once when it loads user history and once when it loads the credentials file.
 
 ### Changed
 - Upgraded to textblocks-0.14, removed support for pragma blocks entirely.

--- a/bin/rm3load
+++ b/bin/rm3load
@@ -21,6 +21,7 @@ program
   .version(pjson.version)
   .option('-d, --directory [dir]','Input directory')
   .option('-f, --file [infile]','Input file','-')
+  .option('-h, --nohistory','Don\'t try to Load history', true)
   .option('-p, --path [path]','Change the path to the new destination path',parse_sitepath)
   .parse(process.argv);
 
@@ -33,7 +34,7 @@ if (program.directory) {
 
   workflow.loadConf(function() {
     runWorkflows(function() {
-      loaddump.loadFromCatalog(db, program.directory, program.path, new SitePath(['wh','users']), function(err) {
+      loaddump.loadFromCatalog(db, program.directory, program.path, new SitePath(['wh','users']), !program.nohistory, function(err) {
         if (err) {
           winston.error('Error:', err);
           db.gunDatabase();
@@ -66,7 +67,7 @@ if (program.directory) {
   stdin.on('end', function () {
     var inputData = inputChunks.join();
     var parsedData = JSON.parse(inputData);
-    loaddump.loadEntity(db, parsedData, program.path, false, {}, function(err) {
+    loaddump.loadEntity(db, parsedData, program.path, false, !program.nohistory, {}, function(err) {
       if (err) {
         winston.error('Error:', err);
         db.gunDatabase();
@@ -82,7 +83,7 @@ if (program.directory) {
       winston.error('Error:', err);
       process.exit(1);
     }
-    loaddump.loadEntity(db, parsedData, program.path, false, {}, function(err) {
+    loaddump.loadEntity(db, parsedData, program.path, false, !program.nohistory, {}, function(err) {
       if (err) {
         winston.error('Error:', err);
         db.gunDatabase();

--- a/lib/loaddump.js
+++ b/lib/loaddump.js
@@ -10,8 +10,36 @@ var Conf = require('../lib/conf'),
     BlobStores = require('../lib/blobstores'),
     FileBlobStore = require('../lib/fileblobstore');
 var Protoset = require('./protoset');
+var SitePath = require('sitepath');
 
-function loadEntity(db, parsedData, entityPath, preserveEntityId, revisions, next) {
+function loadEntityWithHistory(db, security, ent, history, preserveEntityId, next) {
+  if (history) {
+    winston.info('Creating ', {entityId: ent._entityId});
+    async.forEachOfSeries(history, function(entry, key, callback) {
+      winston.info('Forging ', {entityId: ent._entityId,
+        revisionId: entry.revisionId, revisionNum: entry.revisionNum, num: key,
+        length: history.length});
+      entry.path = new SitePath(entry.path).toDottedPath();
+      if (entry.actorPath) {
+        entry.actorPath = new SitePath(entry.actorPath);
+      }
+      update.forgeLogentry(db, {}, security, entry, true, callback);
+    }, function(err) {
+      next(err);
+    });
+  } else {
+    update.loadEntity(db, {}, security, ent, true,
+      'loaded via rm3load', preserveEntityId, function(err, entityId, revisionId, revisionNum) {
+        if (err) {
+          return next(err);
+        }
+        winston.info('Created ', {entityId: entityId, revisionId: revisionId, revisionNum: revisionNum});
+        next(err);
+      });
+  }
+}
+
+function loadEntity(db, parsedData, entityPath, preserveEntityId, loadHistory, revisions, next) {
   var ent = new entity.Entity();
   if (!parsedData.hasOwnProperty('hidden')) {
     parsedData.hidden = false;
@@ -24,12 +52,15 @@ function loadEntity(db, parsedData, entityPath, preserveEntityId, revisions, nex
   if (page.preCreate) {
     page.preCreate(ent);
   }
-  update.loadEntity(db, {}, {context: 'ROOT'}, ent, true,
-    'loaded via rm3load', preserveEntityId, function(err, entityId, revisionId, revisionNum) {
+  var history;
+  if (loadHistory) {
+    history = parsedData.history;
+  }
+  loadEntityWithHistory(db, {context: 'ROOT'}, ent, history, preserveEntityId,
+    function(err, entityId, revisionId, revisionNum) {
       if (err) {
         next(err);
       }
-      winston.info('Created ', {entityId: entityId, revisionId: revisionId, revisionNum: revisionNum});
       if (page.postCreate) {
         async.forEachOf(revisions, function(key, value, callback) {
           page.postCreate({}, ent, value, callback);
@@ -68,7 +99,7 @@ function loadBlobs(catalog, store, catalogPath, next) {
   });
 }
 
-function loadEntities(db, catalog, catalogPath, next) {
+function loadEntities(db, catalog, catalogPath, loadHistory, next) {
   var conf = {
     path: Conf.getPath('localBlobs'),
     urlroot: '/blobs/',
@@ -88,7 +119,7 @@ function loadEntities(db, catalog, catalogPath, next) {
             callback(null, {});
           }
         },
-        loadEntity.bind(this, db, jsonfile.readFileSync(inPath), null, true)
+        loadEntity.bind(this, db, jsonfile.readFileSync(inPath), null, true, loadHistory)
       ], callback);
     } else {
       callback();
@@ -96,10 +127,10 @@ function loadEntities(db, catalog, catalogPath, next) {
   }, next);
 }
 
-function loadFromCatalog(db, catalogPath, entityPath, userPath, next) {
+function loadFromCatalog(db, catalogPath, entityPath, userPath, loadHistory, next) {
   var catalog = jsonfile.readFileSync(path.join(catalogPath, 'catalog.json'));
   async.series([
-    loadEntities.bind(this, db, catalog, catalogPath),
+    loadEntities.bind(this, db, catalog, catalogPath, loadHistory),
     function(callback) {
       winston.info('Loading permissions');
       if (catalog._permissions) {

--- a/lib/update/index.js
+++ b/lib/update/index.js
@@ -754,3 +754,33 @@ exports.deleteBlob = function deleteBlob(db, ctx, category, provider, entityPath
     }
   ], doCleanup.bind(this, db, ctx, next));
 };
+
+/**
+  Creates a log entry for loading history, optionally executes.
+  @param {Object} db DB wrapper
+  @param {Object} ctx Logging context
+  @param {Object} access Access context
+  @param {Object} logentry Logentry to be created
+  @param {Boolean} exec Execute the forged logentry
+  @param {*} next Function that takes(err, entityId, revision_id, revision_num)
+*/
+exports.forgeLogentry = function(db, ctx, access, logentry, exec, next) {
+  boundLogger.info('forgeLogentry', {
+    ctx: ctx,
+    path: logentry._path,
+    revisionId: logentry.revisionId,
+    access: access
+  });
+  async.waterfall([
+    db.connectWrap,
+    db.openTransaction.bind(this,ctx),
+    function generateLogentry(client, done, callback) {
+      addActorToLogentry(logentry, access);
+      callback(null, client, done, logentry);
+    },
+    writeLogentry.bind(this, ctx),
+    execLogentry.bind(this, ctx, exec),
+    writeTags.bind(this, ctx, exec),
+    commit.bind(this, db, ctx)
+  ], doCleanup.bind(this, db, ctx, next));
+};

--- a/tests/cli/test-rm3admin.js
+++ b/tests/cli/test-rm3admin.js
@@ -8,7 +8,7 @@ var sitepath = require ('sitepath');
 var query = require('../../lib/query');
 
 describe('rm3admin', function() {
-  this.timeout(12000); // This might take a bit of time
+  this.timeout(20000); // This might take a bit of time
   it('should add a permission to a role and roleinfo should check', function() {
     childProcess.execSync('./bin/rm3admin permit root edit \\*');
 

--- a/tests/cli/test-rm3load.js
+++ b/tests/cli/test-rm3load.js
@@ -8,7 +8,7 @@ var sitepath = require ('sitepath');
 var query = require('../../lib/query');
 
 describe('rm3load', function() {
-  this.timeout(12000); // This might take a bit of time
+  this.timeout(20000); // This might take a bit of time
   it('should load from a JSON file', function(done) {
     childProcess.execSync('./bin/rm3load -f ./tests/page-fixtures/front.json');
 


### PR DESCRIPTION
- added --nohistory flag to smash history
- breaks on 0.2.0 backups currently because it tries to assign a user to a permission once when it loads user history and once when it loads the credentials file.