### PR TITLE
Added the initialization of schemes to a overridable phase of startup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Justified and Masonry views.
 - Caching SQL requests in redis for findBlob
+- Added the initialization of schemes to a overridable phase of startup.
 
 ### Changed
 - Updated dependencies

--- a/lib/front.js
+++ b/lib/front.js
@@ -174,7 +174,7 @@ phase.addDefaultPhase('scheme', function(app, next) {
   var scheme = new Scheme(path.join(__dirname, '../scheme/default/'), db, cacheService, query);
   app.use(schemeMap(scheme));
   next();
-})
+});
 
 phase.addDefaultPhase('passport-paths', function(app, next) {
   winston.info('front', 'passport-paths startup');

--- a/lib/front.js
+++ b/lib/front.js
@@ -170,6 +170,12 @@ phase.addDefaultPhase('error-handling', function(app, next) {
   next();
 });
 
+phase.addDefaultPhase('scheme', function(app, next) {
+  var scheme = new Scheme(path.join(__dirname, '../scheme/default/'), db, cacheService, query);
+  app.use(schemeMap(scheme));
+  next();
+})
+
 phase.addDefaultPhase('passport-paths', function(app, next) {
   winston.info('front', 'passport-paths startup');
   var forceAuth;
@@ -299,9 +305,10 @@ var front = function(next) {
 
       app.use(bodyParser.json());
       app.use(bodyParser.urlencoded({extended: true}));
-
-      var scheme = new Scheme(path.join(__dirname, '../scheme/default/'), db, cacheService, query);
-      app.use(schemeMap(scheme));
+      next();
+    },
+    phase.runPhase.bind(this,'scheme',app),
+    function(next) {
       app.use(siteMap(db, query));
       next();
     },


### PR DESCRIPTION
Part of #3

If you import the library and replace the scheme phase, you can put in
your own scheme object.