### PR TITLE
Make it easier to use sentry/rollbar/exceptional/etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Cache key for most recent changed is now based on the path root.
+- Re-organized startup phases to make it easier to use debugging tools that catch errors and insert themselves into the express pipeline (sentry, rollbar, exceptional.io, et al)
 
 ## [0.3.4] - Low - 2017-01-08: California Rainpocalypse special edition
 ### Added

--- a/lib/front.js
+++ b/lib/front.js
@@ -51,6 +51,10 @@ var redisCache = new redisModule({redisUrl: Conf.getEndpoint('cacheRedis')}),
     sessionRedisClient = Redis.createClient(Conf.getEndpoint('sessionRedis')),
     rateMiddleware = require('./middleware/ratemiddleware');
 
+phase.addDefaultPhase('before-everything', function(app, next) {
+  next();
+});
+
 phase.addDefaultPhase('logging', function(app, next) {
   winston.remove(winston.transports.Console);
   winston.add(winston.transports.Console, {colorize: true});
@@ -170,6 +174,10 @@ phase.addDefaultPhase('error-handling', function(app, next) {
   app.use(errorHandle.handle404);
   app.use(errorHandle.handle410);
   app.use(errorHandle.handle429);
+  next();
+});
+
+phase.addDefaultPhase('error-default', function(app, next) {
   app.use(errorHandle.errorFallThrough);
   next();
 });
@@ -202,14 +210,16 @@ phase.addDefaultPhase('passport-paths', function(app, next) {
 var front = function(next) {
   var app = express();
 
-  app.disable('x-powered-by');
-  app.use(frameguard());
-  app.use(nosniff());
-
-  app.use(cacheControl());
-  expstate.extend(app);
   async.series([
+    phase.runPhase.bind(this,'before-everything',app),
     function(next) {
+      app.disable('x-powered-by');
+      app.use(frameguard());
+      app.use(nosniff());
+
+      app.use(cacheControl());
+      expstate.extend(app);
+
       app.locals.db = db;
       app.locals.cache = cacheService;
       app.use(function(req, res, next) {
@@ -283,7 +293,8 @@ var front = function(next) {
       });
       next();
     },
-    phase.runPhase.bind(this,'error-handling',app)
+    phase.runPhase.bind(this,'error-handling',app),
+    phase.runPhase.bind(this,'error-default',app)
   ], function(err) {
     if (err) {
       return next(err);


### PR DESCRIPTION
Re-organized startup phases to make it easier to use debugging tools
that catch errors and insert themselves into the express pipeline
(sentry, rollbar, exceptional.io, et al)

Fixes #470